### PR TITLE
Fix undefiend reference to clamp

### DIFF
--- a/src/FaceSolver/calcMouth.js
+++ b/src/FaceSolver/calcMouth.js
@@ -1,5 +1,5 @@
 import Vector from "../utils/vector.js";
-import { remap } from "../utils/helpers.js";
+import { remap, clamp } from "../utils/helpers.js";
 
 /**
  * Calculate Mouth Shape


### PR DESCRIPTION
Hi,

Thank you for sharing such a cool library ! 😎 

I tried to use this library with `esbuild`, and got this error:

<img width="543" alt="スクリーンショット 2021-11-12 0 02 30" src="https://user-images.githubusercontent.com/3530521/141321130-847cb22c-3b78-40fa-8f19-e056d7be83a8.png">

Adding `clamp` to the import statement seems to fix this.