### PR TITLE
Fix(): Prettier error with a fresh install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build:lib": "tsc -p .",
         "serve": "vite",
         "prepare": "npm run build",
-        "fmt": "prettier --write 'src/**/*.ts'",
+        "fmt": "prettier --write \"src/**/*.ts\"",
         "test": "npm run build && npm run dev",
         "lint": "eslint \"src/**/*.ts\" --fix"
     },


### PR DESCRIPTION
Got this error when trying to test a fresh install with 
```
npm install
```
### Error
```
> kalidokit@1.1.4 fmt D:\Libraries\Documents\Repos\kalidokit
> prettier --write 'src/**/*.ts'

[error] No files matching the pattern were found: "'src/**/*.ts'".
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! kalidokit@1.1.4 fmt: `prettier --write 'src/**/*.ts'`
```

FIX: Made the syntax match the eslint command.